### PR TITLE
Convert filter names of IB filters to OBCP names

### DIFF
--- a/qplan/plugins/ControlPanel.py
+++ b/qplan/plugins/ControlPanel.py
@@ -403,8 +403,10 @@ class ControlPanel(PlBase.Plugin):
                 cur_filter = 'y'
             if 'NB0' in cur_filter:
                 cur_filter = cur_filter.replace('NB0', 'NB')
-            # Set all 'NB' flters to lower-case
-            if 'NB' in cur_filter:
+            if 'IB0' in cur_filter:
+                cur_filter = cur_filter.replace('IB0', 'IB')
+            # Set all 'NB' and 'IB' filters to lower-case
+            if ('NB' in cur_filter) or ('IB' in cur_filter):
                 cur_filter = cur_filter.lower()
             self.logger.info('Current filter %s' % (cur_filter))
             self.schedule_qf.update(rownum, 'Cur Filter', cur_filter, False)

--- a/qplan/plugins/HSC.py
+++ b/qplan/plugins/HSC.py
@@ -366,10 +366,12 @@ QUEUE_MODE $DEF_CMNTOOL OBSERVER=
         if name in filternames:
             return filternames[name]
 
-        # narrowband filter
-        if name.startswith('NB'):
+        # narrowband and intermediate-band filter
+        if name.startswith('NB') or name.startswith('IB'):
+            prefix = name[0:2]
             num = int(name[2:])
-            name = "NB%04d" % num
+            name = "%2s%04d" % (prefix, num)
+
         return "%s" % (name)
 
     def get_ag_exp(self, filter_name):


### PR DESCRIPTION
IB filters are currently specified as, e.g., IB945 in Phase 2, but its OBCP name is IB0945.  I implemented this conversion in the commit. I slightly changed the scheme of the conversion so that IB and NB can be treated at the same place. 