### PR TITLE
Replace pytz module with dateutil.tz module

### DIFF
--- a/qplan/Model.py
+++ b/qplan/Model.py
@@ -7,7 +7,6 @@
 import os
 import time
 from datetime import timedelta
-import pytz
 import numpy
 
 # 3rd party imports

--- a/qplan/Scheduler.py
+++ b/qplan/Scheduler.py
@@ -7,7 +7,6 @@
 import os
 import time
 from datetime import timedelta
-import pytz
 import numpy
 from io import BytesIO, StringIO
 

--- a/qplan/common.py
+++ b/qplan/common.py
@@ -1,6 +1,3 @@
-import pytz
-from datetime import timedelta, tzinfo
-
 from . import entity
 from .util import calcpos
 

--- a/qplan/entity.py
+++ b/qplan/entity.py
@@ -6,7 +6,7 @@
 from datetime import timedelta, datetime
 import math
 import dateutil.parser
-import pytz
+from dateutil import tz
 
 # 3rd party imports
 import numpy as np
@@ -571,7 +571,7 @@ class FOCASConfiguration(InstrumentConfiguration):
 class EnvironmentConfiguration(object):
 
     # Default time zone for lower_time_limit and upper_time_limit
-    default_timezone = pytz.utc
+    default_timezone = tz.UTC
 
     def __init__(self, seeing=None, airmass=None, moon='any',
                  transparency=None, moon_sep=None, lower_time_limit=None,
@@ -689,7 +689,7 @@ def parse_date_time(dt_str, default_timezone):
     if len(dt_str) > 0:
         dt = dateutil.parser.parse(dt_str)
         if dt.tzinfo is None:
-            dt = default_timezone.localize(dt)
+            dt = dt.replace(tzinfo=default_timezone)
     else:
         dt = None
     return dt

--- a/qplan/plots/airmass.py
+++ b/qplan/plots/airmass.py
@@ -7,7 +7,6 @@
 #   Copyright (c) 2008 UCO/Lick Observatory.
 #
 from datetime import datetime, timedelta
-import pytz
 import numpy
 
 import matplotlib.dates as mpl_dt
@@ -48,17 +47,10 @@ class AirMassPlot(plots.Plot):
         Plot into `figure` an airmass chart using target data from `info`
         with time plotted in timezone `tz` (a tzinfo instance).
         """
-        ## site = info.site
-        ## tgt_data = info.target_data
-        # Urk! This seems to be necessary even though we are plotting
-        # python datetime objects with timezone attached and setting
-        # date formatters with the timezone
-        tz_str = tz.tzname(None)
-        mpl.rcParams['timezone'] = tz_str
 
         # set major ticks to hours
         majorTick = mpl_dt.HourLocator(tz=tz)
-        majorFmt = mpl_dt.DateFormatter('%Hh')
+        majorFmt = mpl_dt.DateFormatter('%Hh', tz=tz)
         # set minor ticks to 15 min intervals
         minorTick = mpl_dt.MinuteLocator(list(range(0,59,15)), tz=tz)
 
@@ -145,17 +137,10 @@ class AirMassPlot(plots.Plot):
         Plot into `figure` an altitude chart using target data from `info`
         with time plotted in timezone `tz` (a tzinfo instance).
         """
-        ## site = info.site
-        ## tgt_data = info.target_data
-        # Urk! This seems to be necessary even though we are plotting
-        # python datetime objects with timezone attached and setting
-        # date formatters with the timezone
-        tz_str = tz.tzname(None)
-        mpl.rcParams['timezone'] = tz_str
 
         # set major ticks to hours
         majorTick = mpl_dt.HourLocator(tz=tz)
-        majorFmt = mpl_dt.DateFormatter('%Hh')
+        majorFmt = mpl_dt.DateFormatter('%Hh', tz=tz)
         # set minor ticks to 15 min intervals
         minorTick = mpl_dt.MinuteLocator(list(range(0, 59, 15)), tz=tz)
 
@@ -323,7 +308,7 @@ if __name__ == '__main__':
 
     start_time = datetime.strptime("2015-03-30 18:30:00",
                                    "%Y-%m-%d %H:%M:%S")
-    start_time = tz.localize(start_time)
+    start_time = start_time.replace(tzinfo=site.tz_local)
     t = start_time
     # if schedule starts after midnight, change start date to the
     # day before

--- a/qplan/plots/polarsky.py
+++ b/qplan/plots/polarsky.py
@@ -140,7 +140,6 @@ class AZELPlot(plots.Plot):
 if __name__ == '__main__':
     from qplan import entity, common
     from qplan.util.site import get_site
-    import pytz
 
     from ginga import toolkit
     toolkit.use('qt')
@@ -165,7 +164,7 @@ if __name__ == '__main__':
 
     start_time = datetime.strptime("2015-03-27 20:05:00",
                                    "%Y-%m-%d %H:%M:%S")
-    start_time = tz.localize(start_time)
+    start_time = start_time.replace(tzinfo=site.tz_local)
     plot.plot_targets(site, [common.moon, common.sun, tgt3],
                       start_time, ['white', 'yellow', 'green'])
 

--- a/qplan/plugins/AirMassChart.py
+++ b/qplan/plugins/AirMassChart.py
@@ -4,7 +4,7 @@
 # Eric Jeschke (eric@naoj.org)
 #
 from datetime import timedelta
-#import pytz
+#from dateutil import tz
 
 from ginga.gw import Widgets, Plot
 from ginga.misc import Bunch
@@ -22,7 +22,7 @@ class AirMassChart(PlBase.Plugin):
         self.initialized = False
 
         # Set preferred timezone for plot
-        #self.tz = pytz.utc
+        #self.tz = tz.UTC
 
         sdlr = self.model.get_scheduler()
         self.tz = sdlr.timezone

--- a/qplan/tests/test_misc.py
+++ b/qplan/tests/test_misc.py
@@ -1,7 +1,7 @@
 import unittest
 from datetime import timedelta
 import math
-import pytz
+from dateutil import tz
 
 import ephem
 
@@ -16,8 +16,8 @@ altair = ("19:51:29.74", "8:54:23.5", "2000")
 class TestEntity01(unittest.TestCase):
 
     def setUp(self):
-        self.hst = pytz.timezone('US/Hawaii')
-        self.utc = pytz.utc
+        self.hst = tz.gettz('US/Hawaii')
+        self.utc = tz.UTC
         self.obs = entity.Observer('subaru',
                                    longitude='-155:28:48.900',
                                    latitude='+19:49:42.600',
@@ -118,7 +118,7 @@ class TestEntity01(unittest.TestCase):
                                     '00:22:13.44', '-00:36:25.20')
         am = observer.tools.Airmass(obs.almanac_data, tgt)
         time1 = self.obs.get_date("2010-10-18 22:00")
-        time1_ut = time1.astimezone(pytz.utc)
+        time1_ut = time1.astimezone(tz.UTC)
         tup = am.compute_one(tgt.target, time1_ut)
         amass = tup[4]
 

--- a/qplan/util/site.py
+++ b/qplan/util/site.py
@@ -2,7 +2,7 @@
 # site.py -- module containing different preconfigured observing sites
 #
 
-import pytz
+from dateutil import tz
 from qplan.util.calcpos import Observer
 
 # Subaru Telescope
@@ -12,7 +12,7 @@ site_subaru = Observer('subaru',
                        elevation=4163,
                        pressure=615,
                        temperature=0,
-                       timezone=pytz.timezone('HST'))
+                       timezone=tz.gettz('US/Hawaii'))
 
 # ---------------------------------
 # Add your site above here...


### PR DESCRIPTION
Some issues with the `pytz` module have been identified and the general consensus seems to indicate that the preferred solution is to switch to the `dateutil.tz` module instead.  This PR does that.