### PR TITLE
fix typo in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,5 @@
 [build-system]
-requires = ["setuptools>=>=45",
-            "setuptools_scm[toml]>=6.2",
-            "wheel"]
+requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
Fix a minor typo in `pyproject.toml`.  Minor formatting was made, but I believe this shouldn't matter for this case.